### PR TITLE
various fixes to deploy-doc.sh

### DIFF
--- a/deploy-doc.sh
+++ b/deploy-doc.sh
@@ -2,22 +2,42 @@
 # $1 = User Name
 # $2 = Repo Name
 # $3 = version
-git clone git@github.com:$1/$2.git
-cd $2
+
+# Clone repository if it doesn't already exist.
+# Otherwise just update it.
+if [ ! -d $2 ]
+then
+	git clone git@github.com:$1/$2.git
+	cd $2
+else
+	cd $2
+	git checkout $3
+	git pull
+fi
+
 git checkout gh-pages
-mkdir -p docs
-cd docs
-mkdir $3
-cd ..
+mkdir -p docs/$3
+
+# Get doc files from master branch into a clean directory (without .git* metadata)
+rm -rf docsco
 mkdir docsco
 git --work-tree=docsco checkout $3 -- docs
-cd docsco
-# .md -> .html
-find . -name "*.md" -exec sed -i.bak "s/.md/.html/g" '{}' \;
-find . -name "*.bak" -type f | xargs /bin/rm -f
-cp -R docs/* ../docs/$3
-cd ..
-rm -rf docsco
-git add --all .
+
+# Convert ibm-js links from .md -> .html
+# Ex: [...](./Container.md), or [...](/decor/docs/master/Stateful.md)
+# However, don't convert absolute URLs that are supposed to go to .md files, like
+# https://github.com/SitePen/dstore/blob/master/README.md
+find docsco -name "*.md" -exec sed -i.bak \
+	-e 's/\(http.*\)\.md/\1.XXX/g' \
+	-e 's/\.md/.html/g' \
+	-e 's/.XXX/.md/g' \
+	'{}' \;
+find docsco -name "*.bak" -type f | xargs /bin/rm -f
+
+
+# Check in updated doc files into gh-pages branch
+cp -R docsco/docs/* docs/$3
+git add --all docs
 git commit -m "update doc"
+
 git push origin gh-pages


### PR DESCRIPTION
various fixes to deploy-doc.sh, including NOT converting the link

`https://github.com/SitePen/dstore/blob/master/README.md`

into

`https://github.com/SitePen/dstore/blob/master/README.html`

Also made it more resilient to directories already existing.

PS: Eventually the .md --> .html extension conversion should be done using jekyll filters rather than shell scripts.   Modify all the _layouts/*.html files to say:

```
{{ page.content | convertLinks }}
```

and then define that convertLinks filter as something like https://github.com/bdesham/pluralize/blob/master/pluralize.rb.

So this is somewhat of a temporary solution.
